### PR TITLE
change check_url route to use query param instead of path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    prove_keybase (0.1.2)
-      active_model_serializers
-      faraday
-      faraday_middleware
+    prove_keybase (0.1.3)
+      active_model_serializers (~> 0.10)
+      faraday (~> 0.15)
+      faraday_middleware (~> 0.13)
 
 GEM
   remote: https://rubygems.org/
@@ -215,15 +215,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt
+  bcrypt (~> 3.1)
   prove_keybase!
   pry
   rails (~> 5.2.3)
-  rspec-rails
+  rspec-rails (~> 3.8)
   rubocop
-  sqlite3
-  travis
-  webmock
+  sqlite3 (~> 1.4)
+  travis (~> 1.8)
+  webmock (~> 3.7)
 
 BUNDLED WITH
    1.17.2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 ProveKeybase::Engine.routes.draw do
   get 'config', to: 'config#show'
   resources :proofs, only: [:new, :create]
-  get 'api/v1/proofs/:username', to: 'api_v1_proofs#show', as: :check_proof
+  get 'api/v1/proofs', to: 'api_v1_proofs#show', as: :check_proof
 end

--- a/spec/controllers/config_controller_spec.rb
+++ b/spec/controllers/config_controller_spec.rb
@@ -20,7 +20,7 @@ describe ProveKeybase::ConfigController, type: :controller do
 
       config = JSON.parse(response.body)
       expect(config['profile_url']).to eq 'https://example.test/users/%{username}'
-      expect(config['check_url']).to eq "https://example.test/prove_keybase/api/v1/proofs/%{username}"
+      expect(config['check_url']).to eq "https://example.test/prove_keybase/api/v1/proofs?username=%{username}"
     end
   end
 end

--- a/spec/integration/proof_creation_spec.rb
+++ b/spec/integration/proof_creation_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Proof Creation', type: :request, order: :defined do
     # dumbed-down version of what keybase is actually doing
     # to determine whether or not a proof is "live"
     username = request.uri.query_values['username']
-    get "/prove_keybase/api/v1/proofs/#{username}"
+    get "/prove_keybase/api/v1/proofs?username=#{username}"
 
     local_api_response = JSON.parse(response.body)['signatures']
     proof_live = (local_api_response == [{ 'sig_hash' => token, 'kb_username' => kb_username }])


### PR DESCRIPTION
move the username in check_url (the one keybase calls to see that a proof is being hosted by the remote domain) from being a url path param to a query string param. 
this is better if the username happens to have characters in it that need to be url-encoded (e.g. a period). 

this is a breaking change for any existing implementations, so it probably requires bumping the version to `0.2.0`. anyone upgrading to this code would not need to change anything on their side (unless they have their own integration tests), but they would need to tell keybase to point at the slightly different url. this is an easy change on the keybase side. we just need to know to do it for you. 